### PR TITLE
add support for updatedAt column in Reservations table

### DIFF
--- a/src/lib/server/server.js
+++ b/src/lib/server/server.js
@@ -247,7 +247,10 @@ function getTimeOverlapFilters(settings, rsv) {
 		}
 		if (slots.beforeStart.length > 0 && slots.afterEnd.length > 0) {
 			timeFilt.push({
-				$all: [{ startTime: { $any: slots.beforeStart } }, { endTime: { $any: slots.afterEnd } }]
+				$all: [
+					{ startTime: { $any: slots.beforeStart } },
+					{ endTime: { $any: slots.afterEnd } }
+				]
 			});
 		}
 		filters.push({
@@ -397,14 +400,19 @@ export async function updateReservation(formData) {
 		buddySet.add(id);
 	}
 
-	let createdAt = new Date();
-	let modify = [{ ...sub, createdAt }];
+	let updatedAt = new Date();
+	let modify = [{ ...sub, updatedAt }];
 	let create = [];
 	let cancel = [];
 
 	if (buddySet.size > 0) {
 		let existingBuddies;
-		let { user, buddies, id, ...common } = sub;
+		let { user, buddies, ...common } = sub;
+
+		delete common.id;
+		delete common.createdAt;
+		delete common.updatedAt;
+
 		if (oldBuddies.length > 0) {
 			existingBuddies = await getOverlappingReservations(orig, oldBuddies);
 		}
@@ -416,7 +424,7 @@ export async function updateReservation(formData) {
 				let bg = [user, ...buddies.filter((bIdp) => bIdp != bId)];
 				let entry = {
 					...common,
-					createdAt,
+					updatedAt,
 					id: rsvId,
 					user: bId,
 					buddies: bg,
@@ -428,7 +436,8 @@ export async function updateReservation(formData) {
 				let bg = [user, ...buddies.filter((bIdp) => bIdp != bId)];
 				let entry = {
 					...common,
-					createdAt,
+					updatedAt,
+					createdAt: updatedAt,
 					user: bId,
 					buddies: bg,
 					owner: false


### PR DESCRIPTION
Add a column to the Reservations table to track when reservations are updated.  There is already a createdAt column that tracks creation time.  (Actually in a recent commit, I modified createdAt to actually track the modification time; so this commit makes createdAt a proper creation-time value while also adding a dedicated modification-time value.)

Suggest merging this directly to main to avoid complicating the conversion to typescript going on in dev.

Note that the xata main branch's schema and xata.codegen.server.js need to be updated before merging this.