### PR TITLE
make dateFn signature consistent; remove unused code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2391,9 +2391,15 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2608,9 +2614,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2619,10 +2625,14 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -2907,9 +2917,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.18.0.tgz",
-			"integrity": "sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.25.0.tgz",
+			"integrity": "sha512-FnJkNRst2jEZGw7f+v4hFo6UTzpDKrAKcHZWcEfm5/GJQ5CK7wgb4moNLNAe7npKUev7yQn1AY/YbZRIxOv6Qg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -3686,15 +3696,14 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/vite": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
-			"integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+			"integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.16.14",
-				"postcss": "^8.4.21",
-				"resolve": "^1.22.1",
-				"rollup": "^3.10.0"
+				"esbuild": "^0.17.5",
+				"postcss": "^8.4.23",
+				"rollup": "^3.21.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -3750,395 +3759,6 @@
 			},
 			"peerDependencies": {
 				"vite": ">=3"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-			"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-			"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-			"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-			"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-			"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-			"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-			"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-			"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-			"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-			"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-			"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-			"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-			"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-			"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-			"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-			"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-			"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-			"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-			"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.16.17",
-				"@esbuild/android-arm64": "0.16.17",
-				"@esbuild/android-x64": "0.16.17",
-				"@esbuild/darwin-arm64": "0.16.17",
-				"@esbuild/darwin-x64": "0.16.17",
-				"@esbuild/freebsd-arm64": "0.16.17",
-				"@esbuild/freebsd-x64": "0.16.17",
-				"@esbuild/linux-arm": "0.16.17",
-				"@esbuild/linux-arm64": "0.16.17",
-				"@esbuild/linux-ia32": "0.16.17",
-				"@esbuild/linux-loong64": "0.16.17",
-				"@esbuild/linux-mips64el": "0.16.17",
-				"@esbuild/linux-ppc64": "0.16.17",
-				"@esbuild/linux-riscv64": "0.16.17",
-				"@esbuild/linux-s390x": "0.16.17",
-				"@esbuild/linux-x64": "0.16.17",
-				"@esbuild/netbsd-x64": "0.16.17",
-				"@esbuild/openbsd-x64": "0.16.17",
-				"@esbuild/sunos-x64": "0.16.17",
-				"@esbuild/win32-arm64": "0.16.17",
-				"@esbuild/win32-ia32": "0.16.17",
-				"@esbuild/win32-x64": "0.16.17"
 			}
 		},
 		"node_modules/vitefu": {

--- a/src/lib/components/ResFormClassroom.svelte
+++ b/src/lib/components/ResFormClassroom.svelte
@@ -2,7 +2,7 @@
 	import ResFormPool from '$lib/components/ResFormPool.svelte';
 	import type { ReservationData } from '$types';
 
-	export let rsv: ReservationData;
+	export let rsv: ReservationData | null = null;
 	export let category = 'classroom';
 	export let date: Date | null = null;
 	export let dateFn = null;

--- a/src/lib/components/ResFormOpenWater.svelte
+++ b/src/lib/components/ResFormOpenWater.svelte
@@ -1,6 +1,5 @@
 <script>
-	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
-	import { canSubmit, buoys, reservations, user } from '$lib/stores';
+	import { canSubmit, buoys, reservations } from '$lib/stores';
 	import { adminView, buoyDesc } from '$lib/utils.js';
 	import { Settings } from '$lib/settings.js';
 	import ResFormGeneric from '$lib/components/ResFormGeneric.svelte';
@@ -15,12 +14,11 @@
 	let disabled = viewOnly || restrictModify;
 
 	date =
-		rsv == null ? (date == null ? dateFn() : datetimeToLocalDateStr(new Date(date))) : rsv.date;
+		rsv == null ? (date == null ? dateFn(category) : date) : rsv.date;
 
 	let resType = rsv == null ? 'autonomous' : rsv.resType;
 	let maxDepth = rsv == null || rsv.maxDepth == null ? null : rsv.maxDepth;
 	let owTime = rsv == null ? 'AM' : rsv.owTime;
-	let comments = rsv == null ? null : rsv.comments;
 	let numStudents = rsv == null || rsv.resType !== 'course' ? 1 : rsv.numStudents;
 	let pulley = rsv == null ? null : rsv.pulley;
 	let extraBottomWeight = rsv == null ? false : rsv.extraBottomWeight;

--- a/src/lib/components/ResFormPool.svelte
+++ b/src/lib/components/ResFormPool.svelte
@@ -13,7 +13,7 @@
 	export let rsv: ReservationData | null = null;
 	export let category = 'pool';
 	export let date: string | null = null;
-	export let dateFn: null | (() => Date) = null;
+	export let dateFn: null | ((string) => string) = null;
 	export let resType: null | 'course' | 'autonomous' = null;
 	export let viewOnly = false;
 	export let restrictModify = false;
@@ -22,13 +22,7 @@
 
 	let disabled = viewOnly || restrictModify;
 
-	date =
-		!rsv || !rsv?.date ? 
-			(
-				date || !dateFn || (rsv === null) ?
-					datetimeToLocalDateStr(date ? new Date(date) : new Date()) :
-					datetimeToLocalDateStr(dateFn())
-			) : rsv.date;
+	date = !rsv || !rsv?.date ? (date ? date : dateFn(category)) : rsv.date;
 
 	const getStartTimes = (date: string, category: string) => {
 		let startTs = startTimes(Settings, date, category);

--- a/src/lib/components/ReservationDialog.svelte
+++ b/src/lib/components/ReservationDialog.svelte
@@ -2,9 +2,6 @@
 	import { getContext } from 'svelte';
 	import ReservationForm from './ReservationForm.svelte';
 	import ReservationButton from './ReservationButton.svelte';
-	import { reservations } from '$lib/stores';
-	import { minValidDateStr } from '$lib/reservationTimes.js';
-	import { Settings } from '$lib/settings.js';
 
 	export let category = 'openwater';
 
@@ -12,7 +9,7 @@
     might depend on values from the database, which may not have
     loaded by the time the page renders, e.g. immediately after 
     a refresh */
-	export let dateFn = minValidDateStr;
+	export let dateFn;
 
 	const { open } = getContext('simple-modal');
 

--- a/src/lib/components/ReservationForm.svelte
+++ b/src/lib/components/ReservationForm.svelte
@@ -6,9 +6,8 @@
 	import ResFormClassroom from './ResFormClassroom.svelte';
 	import ResFormOpenWater from './ResFormOpenWater.svelte';
 	import { popup } from './Popup.svelte';
-	import { canSubmit, user, users, reservations, buoys } from '$lib/stores';
+	import { users, reservations, buoys } from '$lib/stores';
 	import { beforeResCutoff } from '$lib/reservationTimes.js';
-	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
 	import { Settings } from '$lib/settings.js';
 	import {
 		checkNoOverlappingRsvs,
@@ -102,7 +101,8 @@
 							popup(result.data.message);
 						} else if (result.data.code === 'USER_DISABLED') {
 							popup(
-								'Reservation rejected! User does not have permission to ' + 'make reservations'
+								'Reservation rejected! User does not have permission to ' +
+									'make reservations'
 							);
 						}
 					}
@@ -121,11 +121,11 @@
 		<div class="form-title">reservation request</div>
 		<form method="POST" action="/?/submitReservation" use:enhance={submitReservation}>
 			{#if category === 'pool'}
-				<ResFormPool bind:date dateFn={() => dateFn(Settings, 'pool')} bind:category />
+				<ResFormPool bind:date {dateFn} bind:category />
 			{:else if category === 'openwater'}
-				<ResFormOpenWater bind:date dateFn={() => dateFn(Settings, 'openwater')} bind:category />
+				<ResFormOpenWater bind:date {dateFn} bind:category />
 			{:else if category === 'classroom'}
-				<ResFormClassroom bind:date dateFn={() => dateFn(Settings, 'classroom')} bind:category />
+				<ResFormClassroom bind:date {dateFn} bind:category />
 			{/if}
 		</form>
 	</div>

--- a/src/routes/multi-day/[category]/+page.svelte
+++ b/src/routes/multi-day/[category]/+page.svelte
@@ -8,8 +8,9 @@
 	import Chevron from '$lib/components/Chevron.svelte';
 	import { minValidDateStr } from '$lib/reservationTimes.js';
 	import { idx2month } from '$lib/datetimeUtils';
-	import { user, view, viewedMonth, reservations } from '$lib/stores';
+	import { view, viewedMonth, reservations } from '$lib/stores';
 	import { CATEGORIES } from '$lib/constants.js';
+	import { Settings } from '$lib/settings.js';
 
 	export let data;
 
@@ -118,7 +119,12 @@
 		<span class="text-2xl">{idx2month[gMonth]}</span>
 	</div>
 	<span class="">
-		<Modal><ReservationDialog category={gCategory} dateFn={minValidDateStr} /></Modal>
+		<Modal
+			><ReservationDialog
+				category={gCategory}
+				dateFn={(cat) => minValidDateStr(Settings, cat)}
+			/></Modal
+		>
 	</span>
 </div>
 <div
@@ -141,7 +147,9 @@
 			{#each gMonthArr() as week}
 				<tr>
 					{#each week as { date, rsvs }}
-						<td class="{catStyle(gCategory)} align-top h-20 xs:h-24 border border-solid">
+						<td
+							class="{catStyle(gCategory)} align-top h-20 xs:h-24 border border-solid"
+						>
 							<DayOfMonth {date} category={gCategory} {rsvs} />
 						</td>
 					{/each}

--- a/src/routes/single-day/[category]/+page.svelte
+++ b/src/routes/single-day/[category]/+page.svelte
@@ -179,7 +179,7 @@
 	</div>
 	<span class="mr-2">
 		<Modal
-			><ReservationDialog {category} dateFn={() => datetimeToLocalDateStr($viewedDate)} /></Modal
+			><ReservationDialog {category} dateFn={(cat) => datetimeToLocalDateStr($viewedDate)} /></Modal
 		>
 	</span>
 </div>


### PR DESCRIPTION
@getneil does this resolve the dateFn type issues?  Now it's dateFn: (string) -> string.  

There is one instance, in the single-day +page.svelte, where the arg is unused... a bit sloppy but maybe acceptable?