### PR TITLE
make "local time" on the client always be Panglao local time

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
 	"dependencies": {
 		"@xata.io/client": "^0.22.4",
 		"daisyui": "^2.51.5",
-		"dayjs": "^1.11.8",
+		"dayjs": "^1.11.9",
 		"jszip": "^3.10.1",
 		"lodash": "^4.17.21",
 		"objects-to-csv": "^1.3.6",
 		"svelte-french-toast": "^1.0.3",
-		"svelte-gestures": "^1.4.1"
+		"svelte-gestures": "^1.4.1",
+		"timezone": "^1.0.23",
+		"utc": "^0.1.0"
 	}
 }

--- a/src/lib/components/DayOfMonth.svelte
+++ b/src/lib/components/DayOfMonth.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { goto } from '$app/navigation';
-	import { view, viewedDate } from '$lib/stores';
+	import { viewedDate } from '$lib/stores';
+	import { PanglaoDate } from '$lib/datetimeUtils';
 
 	export let date;
 	export let rsvs;
@@ -11,17 +12,8 @@
 		goto('/single-day/{category}');
 	}
 
-	const catBg = (cat) =>
-		cat === 'pool'
-			? 'bg-pool-bg-to'
-			: cat === 'openwater'
-			? 'bg-openwater-bg-to'
-			: cat === 'classroom'
-			? 'bg-classroom-bg-to'
-			: undefined;
-
 	const dateStyle = (date) => {
-		let today = new Date();
+		let today = PanglaoDate();
 		if (
 			date.getFullYear() == today.getFullYear() &&
 			date.getMonth() == today.getMonth() &&
@@ -36,7 +28,10 @@
 		if (owTime) {
 			return rsvs
 				.filter((rsv) => rsv.owTime === owTime)
-				.reduce((n, rsv) => (rsv.resType === 'course' ? n + 1 + rsv.numStudents : n + 1), 0);
+				.reduce(
+					(n, rsv) => (rsv.resType === 'course' ? n + 1 + rsv.numStudents : n + 1),
+					0
+				);
 		} else {
 			return rsvs.reduce(
 				(n, rsv) => (rsv.resType === 'course' ? n + 1 + rsv.numStudents : n + 1),

--- a/src/lib/components/MyReservations.svelte
+++ b/src/lib/components/MyReservations.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
+	import { datetimeToLocalDateStr, PanglaoDate } from '$lib/datetimeUtils';
 	import { minuteOfDay, beforeCancelCutoff } from '$lib/reservationTimes.js';
 	import { timeStrToMin } from '$lib/datetimeUtils';
 	import { user, userPastReservations, reservations } from '$lib/stores';
@@ -17,7 +17,7 @@
 
 	function getResPeriod(rsv: ReservationData) {
 		let view;
-		let today = new Date();
+		let today = PanglaoDate();
 		let todayStr = datetimeToLocalDateStr(today);
 		if (rsv.date && rsv.date > todayStr) {
 			view = 'upcoming';

--- a/src/lib/components/ResFormGeneric.svelte
+++ b/src/lib/components/ResFormGeneric.svelte
@@ -5,12 +5,13 @@
 	import { canSubmit, user, users } from '$lib/stores';
 	import { Settings } from '$lib/settings.js';
 	import { minValidDateStr, maxValidDateStr } from '$lib/reservationTimes.js';
+	import { PanglaoDate } from '$lib/datetimeUtils';
 	import BuddyMatch from '$lib/components/BuddyMatch.svelte';
 	import PlusIcon from '$lib/components/PlusIcon.svelte';
 	import DeleteIcon from '$lib/components/DeleteIcon.svelte';
 
 	export let rsv: ReservationData | null;
-	export let date: string | null = rsv?.date || new Date().toString();
+	export let date: string | null = rsv?.date || PanglaoDate().toString();
 	export let category: ReservationCategory | string =
 		rsv?.category.toString() || ReservationCategory.pool;
 	export let viewOnly = false;
@@ -24,7 +25,7 @@
 
 	$: maxBuddies =
 		category === 'openwater'
-			? 3 
+			? 3
 			: category === 'pool'
 			? 1
 			: category === 'classroom'
@@ -119,7 +120,9 @@
 			if (e.key === 'ArrowDown' && hiLiteIndex <= currentBF.matches.length - 1) {
 				hiLiteIndex === null ? (hiLiteIndex = 0) : (hiLiteIndex += 1);
 			} else if (e.key === 'ArrowUp' && hiLiteIndex !== null) {
-				hiLiteIndex === 0 ? (hiLiteIndex = currentBF.matches.length - 1) : (hiLiteIndex -= 1);
+				hiLiteIndex === 0
+					? (hiLiteIndex = currentBF.matches.length - 1)
+					: (hiLiteIndex -= 1);
 			} else if (e.key === 'Enter') {
 				e.preventDefault();
 				setInputVal(currentBF.matches[hiLiteIndex]);
@@ -186,7 +189,9 @@
 	</div>
 	<div class="column inputs text-left w-[67%]">
 		{#if viewOnly}
-			<div class={statusStyle(rsv?.status?.toString() || ReservationStatus.pending.toString())}>
+			<div
+				class={statusStyle(rsv?.status?.toString() || ReservationStatus.pending.toString())}
+			>
 				{rsv?.status}
 			</div>
 		{/if}

--- a/src/lib/components/ResFormPool.svelte
+++ b/src/lib/components/ResFormPool.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ResFormGeneric from '$lib/components/ResFormGeneric.svelte';
 	import { startTimes, endTimes, minuteOfDay } from '$lib/reservationTimes.js';
-	import { timeStrToMin, datetimeToLocalDateStr } from '$lib/datetimeUtils';
+	import { timeStrToMin, datetimeToLocalDateStr, PanglaoDate } from '$lib/datetimeUtils';
 	import { canSubmit, user } from '$lib/stores';
 	import { Settings } from '$lib/settings.js';
 	import { adminView } from '$lib/utils.js';
@@ -26,7 +26,7 @@
 
 	const getStartTimes = (date: string, category: string) => {
 		let startTs = startTimes(Settings, date, category);
-		let today = new Date();
+		let today = PanglaoDate();
 		if (!disabled && date === datetimeToLocalDateStr(today)) {
 			let now = minuteOfDay(today);
 			startTs = startTs.filter((time) => timeStrToMin(time) > now);

--- a/src/lib/datetimeUtils.ts
+++ b/src/lib/datetimeUtils.ts
@@ -33,9 +33,22 @@ export const firstOfMonthStr = (dateStr: string) => {
 	return m[1] + '01';
 };
 
+const PhilippinesTimezoneOffset = -480;
+
+export const toPanglaoTimezone = (dt: Date) => {
+    let local = dt.getTimezoneOffset();
+    if (local == PhilippinesTimezoneOffset) {
+        return dt;
+    } else {
+        return new Date(dt.getTime() - (PhilippinesTimezoneOffset - local) * 60000);
+    }
+}
+
+export const PanglaoDate = () => toPanglaoTimezone(new Date());
+
 export function datetimeToLocalDateStr(datetime: Date) {
 	let rexp = /([0-9]+)\/([0-9]+)\/([0-9]+).*/;
-	let m = rexp.exec(datetime.toLocaleDateString('en-US'));
+	let m = rexp.exec(toPanglaoTimezone(datetime).toLocaleDateString('en-US'));
 	if (!m) throw new Error('Invalid date string');
 
 	return m[3] + '-' + m[1].padStart(2, '0') + '-' + m[2].padStart(2, '0');
@@ -48,10 +61,10 @@ export function datetimeToDateStr(dt: Date) {
 	return year + '-' + month.toString().padStart(2, '0') + '-' + day.toString().padStart(2, '0');
 }
 
+// the server's local time is always UTC regardless of its physical location
 export function datetimeInPanglaoFromServer() {
-	const PhilippinesOffset = -480;
 	let d = new Date();
-	return new Date(d.getTime() - PhilippinesOffset * 60000);
+	return new Date(d.getTime() - PhilippinesTimezoneOffset * 60000);
 }
 
 export const minToTimeStr = (min: number) =>

--- a/src/lib/datetimeUtils.ts
+++ b/src/lib/datetimeUtils.ts
@@ -1,3 +1,10 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 export const month2idx: { [key: string]: number } = {
 	January: 0,
 	February: 1,
@@ -35,20 +42,11 @@ export const firstOfMonthStr = (dateStr: string) => {
 
 const PhilippinesTimezoneOffset = -480;
 
-export const toPanglaoTimezone = (dt: Date) => {
-    let local = dt.getTimezoneOffset();
-    if (local == PhilippinesTimezoneOffset) {
-        return dt;
-    } else {
-        return new Date(dt.getTime() - (PhilippinesTimezoneOffset - local) * 60000);
-    }
-}
-
-export const PanglaoDate = () => toPanglaoTimezone(new Date());
+export const PanglaoDate = () => new Date(dayjs().tz('Asia/Manila').$d);
 
 export function datetimeToLocalDateStr(datetime: Date) {
 	let rexp = /([0-9]+)\/([0-9]+)\/([0-9]+).*/;
-	let m = rexp.exec(toPanglaoTimezone(datetime).toLocaleDateString('en-US'));
+	let m = rexp.exec(datetime.toLocaleDateString('en-US'));
 	if (!m) throw new Error('Invalid date string');
 
 	return m[3] + '-' + m[1].padStart(2, '0') + '-' + m[2].padStart(2, '0');

--- a/src/lib/reservationTimes.js
+++ b/src/lib/reservationTimes.js
@@ -23,8 +23,8 @@ export function validReservationDate(stns, date, category) {
 }
 
 export function beforeResCutoff(stns, dateStr, startTime, category) {
-	let now = new Date();
-	let tomorrow = new Date();
+	let now = dtu.PanglaoDate();
+	let tomorrow = dtu.PanglaoDate();
 	tomorrow.setDate(now.getDate() + 1);
 	let tomStr = dtu.datetimeToLocalDateStr(tomorrow);
 
@@ -40,7 +40,7 @@ export function beforeResCutoff(stns, dateStr, startTime, category) {
 }
 
 export function beforeCancelCutoff(stns, dateStr, startTime, category) {
-	let now = new Date();
+	let now = dtu.PanglaoDate();
 	let today = dtu.datetimeToLocalDateStr(now);
 	if (dateStr > today) {
 		return true;
@@ -81,9 +81,9 @@ export const endTimes = (stns, dateStr, cat) =>
 		.map((v, i) => dtu.minToTimeStr(minStart(stns, dateStr, cat) + (i + 1) * inc(stns, dateStr)));
 
 export function minValidDate(stns, category) {
-	let today = new Date();
+	let today = dtu.PanglaoDate();
 	let todayStr = dtu.datetimeToLocalDateStr(today);
-	let d = new Date();
+	let d = dtu.PanglaoDate();
 	if (category === 'classroom') {
 		let sTs = startTimes(stns, todayStr, category);
 		let lastSlot = dtu.timeStrToMin(sTs[sTs.length - 1]);
@@ -106,9 +106,9 @@ export function minValidDateStr(stns, category) {
 }
 
 export function maxValidDate(stns) {
-	let today = new Date();
+	let today = dtu.PanglaoDate();
 	let todayStr = dtu.datetimeToLocalDateStr(today);
-	let maxDay = new Date();
+	let maxDay = dtu.PanglaoDate();
 	maxDay.setDate(today.getDate() + stns.get('reservationLeadTimeDays', todayStr));
 	return maxDay;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 		viewMode
 	} from '$lib/stores';
 	import { augmentRsv } from '$lib/utils.js';
-	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
+	import { datetimeToLocalDateStr, PanglaoDate } from '$lib/datetimeUtils';
 	import { loadFB, login, logout } from '$lib/authentication.js';
 	import { toast, Toaster } from 'svelte-french-toast';
 
@@ -58,7 +58,7 @@
 			$buoys = data.buoys;
 		}
 
-		let minDateStr = datetimeToLocalDateStr(new Date());
+		let minDateStr = datetimeToLocalDateStr(PanglaoDate());
 		data = await post('getAppData', { user: $user.id, minDateStr });
 
 		if (data.status === 'success') {
@@ -89,7 +89,7 @@
 	}
 
 	const oneWeekAgo = () => {
-		let d = new Date();
+		let d = PanglaoDate();
 		d.setDate(d.getDate() - 7);
 		return datetimeToLocalDateStr(d);
 	};


### PR DESCRIPTION
Changes to make sure the concept of 'local time' on the client is always relative to Panglao's time zone.  Currently it's the client's physical location that determines the time zone.  This could cause issues if someone were to book something from a different time zone, which may be unlikely but is worth fixing.  Also it makes the app's display of the schedule  "correct" for remote developers like me.