### PR TITLE
Fix issue 25

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -116,7 +116,7 @@
 						$loginState = 'out';
 						throw new Error('Could not get session from database');
 					} else {
-						$user = res.user;
+						$user = res.user || null;
 						$profileSrc = res.photoURL || '';
 						initializeUserSessionData(res.viewMode);
 					}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -108,21 +108,19 @@
 		try {
 			isLoading = true;
 
-			// if $user is not null, then we are just doing a refresh, no need to reload session
-			if ($user == null) {
-				const res = await getSession();
-				if (res.status !== 'success') {
-					$loginState = 'out';
-					throw new Error('Could not get session from database');
-				} else {
-					$user = res.user;
-					$profileSrc = res.photoURL || '';
-					await initializeUserSessionData(res.viewMode);
-				}
-			}
 			const oneWeekAgo = dayjs().locale('en-US').subtract(7, 'day').format('YYYY-MM-DD');
 			// TODO: this is super slow
-			const [resSettings, resAppData] = await Promise.all([
+			const [, resSettings, resAppData] = await Promise.all([
+				getSession().then((res) => {
+					if (res.status !== 'success') {
+						$loginState = 'out';
+						throw new Error('Could not get session from database');
+					} else {
+						$user = res.user;
+						$profileSrc = res.photoURL || '';
+						initializeUserSessionData(res.viewMode);
+					}
+				}),
 				getSettings(),
 				getAppData(oneWeekAgo)
 			]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,10 +5,10 @@
 	import { Tabs, TabList, TabPanel, Tab } from '$lib/tabs.js';
 	import { minValidDateStr } from '$lib/reservationTimes.js';
 	import { Settings } from '$lib/settings.js';
-	import { user, stateLoaded } from '$lib/stores';
+	import { user, stateLoaded, loginState } from '$lib/stores';
 </script>
 
-{#if $stateLoaded}
+{#if $stateLoaded && $loginState === 'in'}
 	<span class="flex items-center justify-between mr-2">
 		<span />
 		<span class="text-lg font-semibold">{$user.name.split(' ')[0]}'s Reservations</span>

--- a/src/routes/multi-day/[category]/+page.svelte
+++ b/src/routes/multi-day/[category]/+page.svelte
@@ -8,7 +8,7 @@
 	import Chevron from '$lib/components/Chevron.svelte';
 	import { minValidDateStr } from '$lib/reservationTimes.js';
 	import { idx2month } from '$lib/datetimeUtils';
-	import { view, viewedMonth, reservations, stateLoaded } from '$lib/stores';
+	import { view, viewedMonth, reservations, loginState, stateLoaded } from '$lib/stores';
 	import { CATEGORIES } from '$lib/constants.js';
 	import { Settings } from '$lib/settings.js';
 
@@ -98,7 +98,7 @@
 
 <svelte:window on:keydown={handleKeypress} />
 
-{#if $stateLoaded}
+{#if $stateLoaded && $loginState === 'in'}
     <div class="[&>*]:mx-auto flex items-center justify-between">
         <div class="dropdown h-8 mb-4">
             <label tabindex="0" class="border border-gray-200 dark:border-gray-700 btn btn-fsh-dropdown"

--- a/src/routes/single-day/[category]/+page.svelte
+++ b/src/routes/single-day/[category]/+page.svelte
@@ -7,7 +7,7 @@
 	import Chevron from '$lib/components/Chevron.svelte';
 	import { datetimeToLocalDateStr, idx2month } from '$lib/datetimeUtils';
 	import Modal from '$lib/components/Modal.svelte';
-	import { view, viewMode, viewedDate, reservations, stateLoaded } from '$lib/stores';
+	import { loginState, stateLoaded, view, viewMode, viewedDate, reservations } from '$lib/stores';
 	import { Settings } from '$lib/settings.js';
 	import { CATEGORIES } from '$lib/constants.js';
 	import { toast } from 'svelte-french-toast';
@@ -147,7 +147,7 @@
 
 <svelte:window on:keydown={handleKeypress} />
 
-{#if $stateLoaded}
+{#if $stateLoaded && $loginState === 'in'}
     <div class="[&>*]:mx-auto flex items-center justify-between">
         <div class="dropdown h-8 mb-4">
             <label tabindex="0" class="border border-gray-200 dark:border-gray-700 btn btn-fsh-dropdown"


### PR DESCRIPTION
Two issues are addressed here.  

1) Ensuring that the FB SDK is always loaded, regardless of cookie status.
2) ~~Ensuring that app state (settings, reservations, etc.) is not loaded unless the user is fully logged in.~~  Nevermind, that first solution caused a different bug.  The latest commit reverts to the initial behavior of loading the app state regardless of the user login state.  Then it uses both `stateLoaded` and `loginState=='in'` to determine if it's safe to load `+page.svelte`s.  The issue was that `$stateLoaded` could be set to true before `$user` is initialized, which caused page-rendering errors.


I'm not sure about the performance implications of these changes, i.e. perhaps there is a faster way to do this...