### PR TITLE
allow admins to modify their own rsvs from the single-day view when admin mode is disabled

### DIFF
--- a/src/lib/components/DayHourly.svelte
+++ b/src/lib/components/DayHourly.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { startTimes, endTimes } from '$lib/reservationTimes.js';
-	import { user, viewedDate, reservations } from '$lib/stores';
+	import { viewedDate, viewMode, reservations } from '$lib/stores';
 	import { datetimeToLocalDateStr, timeStrToMin } from '$lib/datetimeUtils';
 	import { getContext } from 'svelte';
 	import RsvTabs from '$lib/components/RsvTabs.svelte';
@@ -16,7 +16,7 @@
 		open(RsvTabs, {
 			rsvs: rsvs,
 			hasForm: true,
-			disableModify: $user.privileges === 'admin'
+			disableModify: $viewMode === 'admin'
 		});
 	};
 


### PR DESCRIPTION
If someone with admin privileges has switched off the admin view from the sidebar toggle, then allow them to modify their own pool/classroom reservations by clicking on them from the single-day view, just like a normal user can.

Note that this change already exists for openwater reservations.
