### PR TITLE
include original unmodified reservation in checkNoOverlappingReservat…

### DIFF
--- a/src/lib/components/ModifyForm.svelte
+++ b/src/lib/components/ModifyForm.svelte
@@ -100,7 +100,7 @@
 			cancel();
 		}
 
-		let result = checkNoOverlappingRsvs(Settings, submitted, $reservations);
+		let result = checkNoOverlappingRsvs(Settings, rsv, submitted, $reservations);
 		if (result.status === 'error') {
 			popup(result.msg);
 			cancel();

--- a/src/lib/components/ReservationForm.svelte
+++ b/src/lib/components/ReservationForm.svelte
@@ -63,7 +63,7 @@
 			return;
 		}
 
-		result = checkNoOverlappingRsvs(Settings, submitted, $reservations);
+		result = checkNoOverlappingRsvs(Settings, submitted, submitted, $reservations);
 		if (result.status === 'error') {
 			popup(result.msg);
 			cancel();

--- a/src/lib/validationUtils.js
+++ b/src/lib/validationUtils.js
@@ -228,11 +228,11 @@ export function buddysRsv(rsv, sub) {
 	}
 }
 
-export function checkNoOverlappingRsvs(settings, sub, existing) {
+export function checkNoOverlappingRsvs(settings, orig, sub, existing) {
 	let userIds = [sub.user, ...sub.buddies];
 	let overlapping = getOverlappingReservations(settings, sub, existing);
 	for (let rsv of overlapping) {
-		if (rsv.id != sub.id && !buddysRsv(rsv, sub) && userIds.includes(rsv.user.id)) {
+		if (rsv.id != sub.id && !buddysRsv(rsv, orig) && userIds.includes(rsv.user.id)) {
 			return {
 				status: 'error',
 				msg: 'You or one of your buddies has an existing reservation at this time'


### PR DESCRIPTION
Fixes issue with attempting to modify a reservation's start/end time if the reservation includes at least one buddy.

Note that this issue currently exists on all branches.

This merge can probably wait until after the current dev state has been merged to main.