### PR TITLE
Alternate admin comment form

### DIFF
--- a/src/lib/components/AdminComment.svelte
+++ b/src/lib/components/AdminComment.svelte
@@ -1,0 +1,87 @@
+<script>
+	import { adminComments } from '$lib/stores';
+	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
+	import { OWTime } from '$types';
+	import { enhance } from '$app/forms';
+	import { getContext } from 'svelte';
+	import { toast } from 'svelte-french-toast';
+	export let date;
+	export let buoy;
+
+	const { close } = getContext('simple-modal');
+
+	const getThisRsvAdminComments = (date, buoy, owTime, adminComments) => {
+		if (adminComments[date]) {
+			for (let ac of adminComments[date]) {
+				if (ac.buoy == buoy && ac.am_pm == owTime) {
+					return ac.comment;
+				}
+			}
+		}
+		return '';
+	};
+
+	$: owTime = OWTime.AM;
+
+	const adminCommentUpdate = async ({ form, data, action, cancel }) => {
+		close();
+		return async ({ result, update }) => {
+			switch (result.type) {
+				case 'success':
+					const acRec = result.data.record;
+					const date = datetimeToLocalDateStr(acRec.date);
+					for (let i = 0; i < $adminComments[date].length; i++) {
+						if ($adminComments[date][i].id == acRec.id) {
+							$adminComments[date].splice(i, 1);
+							break;
+						}
+					}
+					if (acRec.comment) {
+						$adminComments[date].push(acRec);
+					}
+					$adminComments = { ...$adminComments };
+					break;
+				default:
+					console.error(result);
+					toast.error('Update failed with unknown error!');
+					break;
+			}
+		};
+	};
+</script>
+
+<form method="POST" action="/?/adminCommentUpdate" use:enhance={adminCommentUpdate}>
+	<div class="form-title">buoy {buoy}</div>
+	<input type="hidden" name="date" value={date} />
+	<input type="hidden" name="buoy" value={buoy} />
+	<div class="row m-4">
+		<div class="column text-right w-[33%]">
+			<div class="form-label h-8 mb-0.5">
+				<label for="owTime" class="dark:text-white">owTime</label>
+			</div>
+			<div class="form-label h-8 mb-0.5">
+				<label for="admin_comments" class="dark:text-white">Comments</label>
+			</div>
+		</div>
+		<div class="column w-[67%]">
+			<div>
+				<select id="owTime" name="owTime" bind:value={owTime}>
+					<option value={OWTime.AM}>AM</option>
+					<option value={OWTime.PM}>PM</option>
+				</select>
+			</div>
+			<div>
+				<textarea
+					id="adminComments"
+					name="admin_comments"
+					class="w-44 xs:w-52 flex-1 text-gray-700 dark:text-white"
+					value={getThisRsvAdminComments(date, buoy, owTime, $adminComments)}
+					tabindex="4"
+				/>
+			</div>
+		</div>
+		<div class="w-full inline-flex items-center justify-end">
+			<button type="submit" class="bg-gray-100 mt-1 px-3 py-1">Update</button>
+		</div>
+	</div>
+</form>

--- a/src/lib/components/DayOpenWater.svelte
+++ b/src/lib/components/DayOpenWater.svelte
@@ -13,6 +13,7 @@
 	import { displayTag } from '$lib/utils.js';
 	import { assignRsvsToBuoys } from '$lib/autoAssignOpenWater.js';
 	import { getContext, onMount } from 'svelte';
+	import AdminComment from '$lib/components/AdminComment.svelte';
 	import RsvTabs from '$lib/components/RsvTabs.svelte';
 	import { badgeColor, buoyDesc } from '$lib/utils.js';
 	import { Settings } from '$lib/client/settings';
@@ -27,6 +28,10 @@
 			hasForm: true,
 			disableModify: $viewMode === 'admin'
 		});
+	};
+
+	const showAdminCommentForm = (date, buoy) => {
+		open(AdminComment, { date, buoy });
 	};
 
 	function getOpenWaterSchedule(rsvs, datetime) {
@@ -242,8 +247,9 @@ it should be,
 				{#if buoyInUse(schedule, buoy.name)}
 					{#if $viewMode === 'admin'}
 						<div
-							class="flex mx-2 sm:mx-4 md:mx-8 lg:mx-6 xl:mx-12 items-center justify-between font-semibold"
+							class="cursor-pointer flex mx-2 sm:mx-4 md:mx-8 lg:mx-6 xl:mx-12 items-center justify-between font-semibold"
 							style="height: {rowHeights[buoy.name].header}rem"
+							on:click={showAdminCommentForm(date, buoy.name)}
 						>
 							<span class="text-xl">{buoy.name}</span>
 							<span class="text-sm">{buoyDesc(buoy)}</span>

--- a/src/lib/components/ResFormOpenWater.svelte
+++ b/src/lib/components/ResFormOpenWater.svelte
@@ -7,7 +7,7 @@
 	import { ReservationCategory, ReservationType } from '$types';
 	import { PanglaoDate } from '$lib/datetimeUtils';
 
-	export let rsv: Reservation | null;
+	export let rsv: Reservation | null = null;
 	export let date: string = rsv?.date || PanglaoDate().toString();
 	export let dateFn: null | ((arg0: string) => string) = null;
 	export let category: ReservationCategory = ReservationCategory.openwater;

--- a/src/lib/components/ViewForm.svelte
+++ b/src/lib/components/ViewForm.svelte
@@ -5,7 +5,7 @@
 	import ResFormClassroom from './ResFormClassroom.svelte';
 	import ResFormOpenWater from './ResFormOpenWater.svelte';
 	import { popup } from './Popup.svelte';
-	import { adminComments, reservations, user, users } from '$lib/stores';
+	import { reservations, user, users } from '$lib/stores';
 	import { adminView } from '$lib/utils.js';
 	import { datetimeToLocalDateStr } from '$lib/datetimeUtils';
 	import { toast } from 'svelte-french-toast';
@@ -16,19 +16,6 @@
 	const dispatch = createEventDispatcher();
 
 	const { close } = getContext('simple-modal');
-
-	const getThisRsvAdminComments = (rsv, adminComments) => {
-		if (adminComments[rsv.date]) {
-			for (let ac of adminComments[rsv.date]) {
-				if (ac.buoy == rsv.buoy) {
-					return ac.comment;
-				}
-			}
-		}
-		return '';
-	};
-
-	let thisAdminComments = getThisRsvAdminComments(rsv, $adminComments);
 
 	const copyChanges = (rsv, upd) => {
 		rsv.status = upd.status;
@@ -75,23 +62,9 @@
 		return async ({ result, update }) => {
 			switch (result.type) {
 				case 'success':
-					let updated = result.data.rsvRecord;
+					let updated = result.data.record;
 					copyChanges(rsv, updated);
 					$reservations = [...$reservations];
-					if (result.data.adminCommentRecord) {
-						const acRec = result.data.adminCommentRecord;
-						const date = datetimeToLocalDateStr(acRec.date);
-						for (let i = 0; i < $adminComments[date].length; i++) {
-							if ($adminComments[date][i].id == acRec.id) {
-								$adminComments[date].splice(i, 1);
-								break;
-							}
-						}
-						if (acRec.comment) {
-							$adminComments[date].push(acRec);
-						}
-						$adminComments = { ...$adminComments };
-					}
 					toast.success('Reservation updated!');
 					break;
 				default:
@@ -114,16 +87,6 @@
 		{/if}
 		<input type="hidden" name="id" value={rsv.id} />
 		{#if adminView(true)}
-			<div class="">
-				<label for="admin_comments" class="dark:text-white w-[33%]">Admin Comments</label>
-				<textarea
-					id="adminComments"
-					name="admin_comments"
-					class="w-44 xs:w-52 mb-4 flex-1 text-gray-700 dark:text-white"
-					bind:value={thisAdminComments}
-					tabindex="4"
-				/>
-			</div>
 			<div class="[&>*]:mx-auto w-full inline-flex items-center justify-between">
 				<button formaction="/?/adminUpdateRejected" class="bg-status-rejected px-3 py-1"
 					>Reject</button

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -12,15 +12,8 @@ import { upsertOWReservationAdminComments } from '$lib/server/ow';
 
 const adminUpdateGeneric = async ({ request }) => {
 	const data = await request.formData();
-	const rsvRecord = await adminUpdate(data);
-	const adminComment = data.get('admin_comments');
-	const adminCommentRecord = await upsertOWReservationAdminComments({
-		comment: adminComment,
-		date: data.get('date'),
-		buoy: data.get('buoy'),
-		am_pm: data.get('owTime')
-	});
-	return { rsvRecord, adminCommentRecord };
+	const record = await adminUpdate(data);
+	return { record };
 };
 
 export const actions = {
@@ -77,5 +70,16 @@ export const actions = {
 		if (accept === 'on') {
 			await insertNotificationReceipt(notificationId, userId);
 		}
+	},
+	adminCommentUpdate: async ({ request }) => {
+		const data = await request.formData();
+		const adminComment = data.get('admin_comments');
+		const record = await upsertOWReservationAdminComments({
+			comment: adminComment,
+			date: data.get('date'),
+			buoy: data.get('buoy'),
+			am_pm: data.get('owTime')
+		});
+		return { record };
 	}
 };


### PR DESCRIPTION
@getneil This is an alternate approach that couples the admin comment form to the buoy rather than to the diver's reservation form.  Click on the buoy name to open the comment form.  If you prefer the original way, feel free to reject this PR.

I decided to create this alternate approach after I realized one issue that arose due to my adding the ability for the admin to delete comments.  The issue is that if there is a buoy that already has a proSafety diver and an adminComment assigned to it, and then the admin assigns another proSafety diver to the same buoy, then the existing adminComment would get overwritten by whatever is in the adminComment text field of the new diver's reservation form, including if it's the empty string.  So effectively the admin would have to manually copy the adminComment every time they add another diver to a buoy with at least one diver already.

I think there may also be other potential issues that could arise due to coupling the admin comment form with the reservation rather than with the buoy, since the admin comment db record is only associated with a buoy and not a reservation.