### PR TITLE
disable nav commands in Tabs component when a modal is displayed over it

### DIFF
--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -4,6 +4,7 @@
 
 <script>
 	export let tabIndex = 0;
+	export let disableNav = false;
 	import { swipe } from 'svelte-gestures';
 	import { setContext, onDestroy } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -41,9 +42,11 @@
 		},
 
 		selectTab: (tab) => {
-			const i = tabs.indexOf(tab);
-			selectedTab.set(tab);
-			selectedPanel.set(panels[i]);
+			if (!disableNav) {
+				const i = tabs.indexOf(tab);
+				selectedTab.set(tab);
+				selectedPanel.set(panels[i]);
+			}
 		},
 
 		selectedTab,
@@ -64,18 +67,22 @@
 	}
 
 	function handleKeypress(e) {
-		if (e.keyCode == 37) {
-			prevTab();
-		} else if (e.keyCode == 39) {
-			nextTab();
+		if (!disableNav) {
+			if (e.keyCode == 37) {
+				prevTab();
+			} else if (e.keyCode == 39) {
+				nextTab();
+			}
 		}
 	}
 
 	function handleSwipe(event) {
-		if (event.detail.direction === 'left') {
-			nextTab();
-		} else if (event.detail.direction === 'right') {
-			prevTab();
+		if (!disableNav) {
+			if (event.detail.direction === 'left') {
+				nextTab();
+			} else if (event.detail.direction === 'right') {
+				prevTab();
+			}
 		}
 	}
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,10 @@
 	import { minValidDateStr } from '$lib/reservationTimes';
 	import { Settings } from '$lib/client/settings';
 	import { user, stateLoaded, loginState } from '$lib/stores';
+
+	let modalOpened = false;
+	const onOpen = () => (modalOpened = true);
+	const onClose = () => (modalOpened = false);
 </script>
 
 {#if $stateLoaded && $loginState === 'in'}
@@ -14,19 +18,19 @@
 		<span class="text-lg font-semibold">{$user.name.split(' ')[0]}'s Reservations</span>
 		<Modal><ReservationDialog dateFn={(cat) => minValidDateStr(Settings, cat)} /></Modal>
 	</span>
-	<Tabs>
+	<Tabs disableNav={modalOpened}>
 		<TabList>
 			<Tab>Upcoming</Tab>
 			<Tab>Completed</Tab>
 		</TabList>
 
 		<TabPanel>
-			<Modal>
+			<Modal on:open={onOpen} on:close={onClose}>
 				<MyReservations resPeriod="upcoming" />
 			</Modal>
 		</TabPanel>
 		<TabPanel>
-			<Modal>
+			<Modal on:open={onOpen} on:close={onClose}>
 				<MyReservations resPeriod="past" />
 			</Modal>
 		</TabPanel>


### PR DESCRIPTION
A small bug fix that disables navigation commands in the Tabs component on the MyReservations page (disables changing between Upcoming and Completed tabs) when the modal is being displayed over it.