### PR TITLE
3 changes to styling

### DIFF
--- a/src/lib/components/DayOpenWaterSubmissionsCard.svelte
+++ b/src/lib/components/DayOpenWaterSubmissionsCard.svelte
@@ -2,25 +2,33 @@
 	import type { Submission } from '$types';
 	import { displayTag } from '$lib/utils.js';
 	import { badgeColor } from '$lib/utils.js';
+	import { user } from '$lib/stores';
+
 	export let submissions: Submission[];
 	export let adminView: boolean = false;
 
 	export let onClick: (e: MouseEvent) => void = () => {};
 
 	export let adminComment: string = '';
+
+	const curUserStyling = (rsv) => {
+		if (rsv.user.id === $user.id) {
+			return 'border border-transparent rounded bg-lime-300 text-black';
+		} else {
+			return '';
+		}
+	};
 </script>
 
 {#if submissions.length}
 	<!-- svelte-ignore a11y-click-events-have-key-events -->
 	<div class="text-center w-full" on:click={onClick}>
 		<div
-			class="bg-openwater-bg-from py-2 pr-1 flex flex-col gap-1 rounded-md cursor-pointer openwater text-sm"
+			class="bg-gradient-to-br from-openwater-bg-from to-openwater-bg-to text-openwater-fg py-0.5 sm:py-2 pr-1 flex flex-col rounded-md cursor-pointer text-sm"
 		>
 			{#each submissions as rsv, i}
 				<div class="flex items-center w-full px-2">
-					<div
-						class="flex-1 text-xs lg:text-base border border-transparent rounded bg-lime-300 text-black overflow-auto break-all"
-					>
+					<div class="flex-1 text-xs lg:text-base {curUserStyling(rsv)} overflow-auto break-all">
 						{displayTag(rsv, adminView)}
 					</div>
 					<div class="pl-1 w-1">

--- a/src/lib/components/DayOpenWaterV2.svelte
+++ b/src/lib/components/DayOpenWaterV2.svelte
@@ -4,7 +4,6 @@
 		buoys,
 		boatAssignments,
 		reservations,
-		profileSrc,
 		viewMode,
 		viewedDate
 	} from '$lib/stores';
@@ -150,14 +149,6 @@
 		}
 	};
 
-	const boatCountPos = (profileSrc) => {
-		if (profileSrc != null) {
-			return 'top-[50px] sm:top-[120px] md:top-[110px]';
-		} else {
-			return 'top-[100px] xs:top-[110px] lg:top-[100px]';
-		}
-	};
-
 	onMount(() => {
 		loadAdminComments();
 	});
@@ -192,16 +183,14 @@
 				};
 			})
 			.filter((v) => v.amReservations.length > 0 || v.pmReservations.length > 0);
-
-		console.log(buoyGroupings);
 	}
+
+	const boatColWidth = (viewMode) => (viewMode == 'admin' ? 'w-20' : 'w-8');
 </script>
 
 {#if $viewMode === 'admin'}
 	<div
-		class="fixed sm:text-xl left-1/2 lg:left-2/3 -translate-x-1/2 whitespace-nowrap w-fit {boatCountPos(
-			$profileSrc
-		)} opacity-70 z-10 bg-gray-100 dark:bg-gray-400 rounded-lg border border-black dark:text-black px-1"
+		class="fixed sm:text-xl left-1/2 lg:left-2/3 -translate-x-1/2 whitespace-nowrap w-fit top-[50px] sm:top-[120px] md:top-[110px] opacity-70 z-10 bg-gray-100 dark:bg-gray-400 rounded-lg border border-black dark:text-black px-1"
 	>
 		<span>boat counts:</span>
 		{#each boats as boat}
@@ -216,15 +205,17 @@
 	<div class="font-semibold text-3xl text-center">Closed</div>
 {:else}
 	<section class="w-full relative block">
-		<header class="flex w-full gap-2 text-xs py-2">
+		<header class="flex w-full gap-0.5 sm:gap-2 text-xs py-2">
 			<div class="flex-none w-12 min-w-12">buoy</div>
-			<div class="flex-none w-20  text-center" class:w-16={$viewMode === 'admin'}>boat</div>
+			<div class="flex-none {boatColWidth($viewMode)} text-center">boat</div>
 			<div class="grow text-center">AM</div>
 			<div class="grow text-center">PM</div>
 		</header>
-		<ul class="flex flex-col gap-3">
+		<ul class="flex flex-col gap-0.5 sm:gap-3">
 			{#each buoyGroupings as grouping}
-				<li class="flex w-full gap-2 border-b-[1px] border-gray-200 border-opacity-20 pb-2">
+				<li
+					class="flex items-center w-full gap-0.5 sm:gap-2 border-b-[1px] border-gray-200 border-opacity-20 pb-0.5 sm:pb-2"
+				>
 					<div class="flex-none w-12 min-w-12">
 						{#if $viewMode === 'admin'}
 							<!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -232,7 +223,7 @@
 								class="cursor-pointer font-semibold"
 								on:click={() => showAdminCommentForm(date, grouping.buoy)}
 							>
-								<span class="text-xl">{grouping.buoy.name}</span>
+								<span>{grouping.buoy.name}</span>
 								<br />
 								<span class="text-xs">{buoyDesc(grouping.buoy)}</span>
 							</div>
@@ -242,7 +233,7 @@
 							</div>
 						{/if}
 					</div>
-					<div class="flex-none w-20 min-w-20 px-2 text-center" class:w-16={$viewMode === 'admin'}>
+					<div class="flex-none {boatColWidth($viewMode)} px-2 text-center">
 						{#if $viewMode === 'admin'}
 							<select
 								class="text-sm h-6 w-16 xs:text-xl xs:h-8 xs:w-16"
@@ -260,7 +251,7 @@
 							{grouping.boat || 'UNASSIGNED'}
 						{/if}
 					</div>
-					<div class="grow flex w-auto relative gap-2">
+					<div class="grow flex w-auto relative gap-0.5 sm:gap-2">
 						<div class="w-1/2">
 							<DayOpenWaterSubmissionsCard
 								submissions={grouping.amReservations || []}
@@ -274,7 +265,6 @@
 							<DayOpenWaterSubmissionsCard
 								submissions={grouping.pmReservations || []}
 								onClick={() => {
-									console.log('event');
 									showViewRsvs(grouping.amReservations || []);
 								}}
 								adminComment={grouping.pmAdminComment}


### PR DESCRIPTION
My general goal is to try to reduce the dimensions of the displayed data as much as possible, usually by removing or reducing padding, without cluttering things too much so that the user can see as much of the data as possible on their screen without having to scroll.  I assume 360x640px is the minimum screen size we should support.

3 main changes: 

1) only add lime green highlighting to current user's reservation
2) reduce some gaps/padding on screens with width < 640px
3) modify how boat column width changes for regular vs admin mode
  Two comments for this one:
     First, I found that the syntax `class:w-16={$viewMode === 'admin'}` didn't seem to be working as intended; in my case, the `w-16` was effectively being ignored in admin mode because `w-20` was still present and seemed to take precedence.
     Second, I'm not sure if your intention was to reduce the width in admin mode?  Seems to me that we want to increase the width in admin mode.  So I changed it to be `w-8` in normal mode and `w-20` in admin mode.