### PR TITLE
revert to old pool assignment function due to #72

### DIFF
--- a/src/lib/autoAssign/index.ts
+++ b/src/lib/autoAssign/index.ts
@@ -1,2 +1,3 @@
 export * from './assignRsvsToBuoys';
 export * from './assignHourlySpaces';
+export * from './oldAssignPoolSpaces';

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,7 +1,8 @@
 import { datetimeToLocalDateStr } from './datetimeUtils';
 import { reservations, user, users, viewMode } from './stores';
 import { get } from 'svelte/store';
-import { assignHourlySpaces } from './autoAssign';
+import { assignHourlySpaces, oldAssignPoolSpaces } from './autoAssign';
+import { ReservationCategory } from '$types';
 
 export function monthArr(year, month, reservations) {
 	let daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -80,7 +81,12 @@ export function getDaySchedule(rsvs, datetime, category) {
 		(v) =>
 			['pending', 'confirmed'].includes(v.status) && v.category === category && v.date === today
 	);
-	let result = assignHourlySpaces(rsvs, today, category);
+	let result;
+	if (category == ReservationCategory.classroom) {
+		result = assignHourlySpaces(rsvs, today, category);
+	} else if (category == ReservationCategory.pool) {
+		result = oldAssignPoolSpaces(rsvs, today);
+	}
 	return result;
 }
 


### PR DESCRIPTION
The [hourly auto assign function](https://github.com/superhome-100/superhome-scheduler/blob/f56e13f7a9870a244fe4986c4cb13c9bc26f867a/src/lib/autoAssign/assignHourlySpaces.ts#L140) can fail with an overbooking error even when there is technically enough space available.  This appears to be the cause of the issue that Arnau and Ayako recently reported with pool bookings on Feb. 3.  I was able to reproduce the error by manipulating the order that the reservations are processed by the assignment function.

The old assignment function is much more complex but does not appear to have this bug.  So I suggest reverting to it until we are able to fix the bug in the new code, or otherwise resolve the issue.