### PR TITLE
fix for updatePrices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superhome-scheduler",
-    "version": "0.4.119",
+    "version": "0.4.120",
     "private": true,
     "scripts": {
         "dev": "PUBLIC_STAGE=local vite dev",

--- a/src/routes/api/admin/updatePrices/+server.ts
+++ b/src/routes/api/admin/updatePrices/+server.ts
@@ -62,6 +62,7 @@ export async function GET({ request, locals: { safeGetSession } }: RequestEvent)
 
 		const now = PanglaoDayJs()
 		const nowDay = getYYYYMMDD(now);
+		const firstOfMonth = getYYYYMMDD(new Date(now.year(), now.month()))
 		// need to use supabaseServiceRole because this code run from scheduled worker without user so 
 		// `locals:{supabase}` is not working here
 		const settings = await getSettingsManager(supabaseServiceRole)
@@ -72,7 +73,7 @@ export async function GET({ request, locals: { safeGetSession } }: RequestEvent)
 		const { data: reservations } = await supabaseServiceRole
 			.from('ReservationsWithPrices')
 			.select('*')
-			.gte('date', getYYYYMMDD(now.add(-30, "days")))
+			.gte('date', firstOfMonth)
 			.lte('date', nowDay)
 			.eq('status', ReservationStatus.confirmed)
 			.order("date")


### PR DESCRIPTION
These reservations were affected:
```
with x as (
  select id
    , "user"
    , date
    , category
    , "resType"
    , row_number() over (partition by "user", category, "resType", to_char(date, 'YYYY-MM') order by date, "startTime") as rn
    , price
    , ("priceTemplate" -> 'autoOW')::int as "expectedPrc"
  from "ReservationsWithPrices"
  where date >= '2026-02-01'
    and date <= '2026-03-17'
    and status = 'confirmed'
    and category = 'openwater' and "resType" = 'autonomous'
),
xx as (
select x.*, u.nickname
from x
left join "Users" u on x.user = u.id 
where date >= '2026-02-25'
  and rn <= 12 and price <> "expectedPrc" and price = 0
order by x."user", x.date
)
select *
from xx
```
